### PR TITLE
Extract open access indicator

### DIFF
--- a/paperSave.py
+++ b/paperSave.py
@@ -39,7 +39,7 @@ def saveResults(paperDict, outFileName):
                   "Publisher Address", "Conference name", "Conference location", "Conference date",
                   "Publisher", "ISSN", "ISBN", "CODEN", "PubMed ID", "Language of Original Document",
                   "Abbreviated Source Title", "Document Type", "Source", "Subject", "EID", "duplicatedIn",
-                  "country", "emailHost", "institution", "institutionWithCountry", "authorFull"]
+                  "country", "emailHost", "institution", "institutionWithCountry", "authorFull", "Open Access"]
 
 
 
@@ -98,6 +98,8 @@ def saveResults(paperDict, outFileName):
       paperDicWrite["institution"] = paperOut["institution"]
       paperDicWrite["institutionWithCountry"] = paperOut["institutionWithCountry"]
       paperDicWrite["bothKeywords"] = paperOut["bothKeywords"]
+      
+      paperDicWrite["Open Access"] = paperOut["openAccess"]
 
       writer.writerow(paperDicWrite)
 
@@ -141,6 +143,8 @@ def saveResults(paperDict, outFileName):
 
       paperDicWrite["duplicatedIn"] = ";".join(paperOut["duplicatedIn"])
       paperDicWrite["country"] = paperOut["country"]
+
+      paperDicWrite["OA"] = paperOut["openAccess"]
 
       writer.writerow(paperDicWrite)
 

--- a/paperUtils.py
+++ b/paperUtils.py
@@ -111,6 +111,8 @@ def openFileToDict(ifile, papersDict):
             paperIn["bothKeywords"] = ""
             paperIn["authorFull"] = ""
 
+            paperIn["openAccess"] = ""
+
             for col in row:
                 if colnum >= len(header):
                     break
@@ -214,6 +216,9 @@ def openFileToDict(ifile, papersDict):
                     paperIn["year"] = col.split("-")[0]
                 if headerCol == "affiliation_country":
                     paperIn["affiliations"] = col
+
+                if headerCol == "Open Access":
+                    paperIn["openAccess"] = col
 
                 # WoS fields
                 # if headerCol == "PT": paperIn[""] = col    # Publication Type (J=Journal; B=Book; S=Series; P=Patent)
@@ -321,7 +326,8 @@ def openFileToDict(ifile, papersDict):
                     paperIn["eid"] = col  # Accession Number
                 if headerCol == "PM":
                     paperIn["pubMedId"] = col  # PubMed ID
-                # if headerCol == "OA": paperIn[""] = col      # Open Access Indicator
+                if headerCol == "OA": 
+                    paperIn["openAccess"] = col      # Open Access Indicator
                 # if headerCol == "HC": paperIn[""] = col      # ESI Highly Cited Paper. Note that this field is valued only for ESI subscribers.
                 # if headerCol == "HP": paperIn[""] = col      # ESI Hot Paper. Note that this field is valued only for ESI subscribers.
                 # if headerCol == "DA": paperIn[""] = col      # Date this report was generated.


### PR DESCRIPTION
Extracts the open-access (OA) indicator across datasets.

---

* The open-access indicator is quite similar in the [WoS](https://webofscience.zendesk.com/hc/en-us/articles/20016332411281-Open-Access) and [Scopus](https://blog.scopus.com/changes-to-scopus-open-access-oa-document-tagging/) tagging systems. Although some standardization is necessary in the user code.
* I have tested the code in a personal project, and it worked fine. Not tested in the example dataset.